### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     name: "Build distribution \U0001F4E6"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Potential fix for [https://github.com/josevnz/SuricataLog/security/code-scanning/2](https://github.com/josevnz/SuricataLog/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `build` job. Since the `build` job only involves checking out the code, setting up Python, installing dependencies, and building the distribution, it does not require write permissions. The minimal permission required is `contents: read`. This change will explicitly limit the permissions of the `GITHUB_TOKEN` for the `build` job, ensuring it cannot perform unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
