### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 # Run code through RUff
 ---
 name: Ruff action
+permissions:
+  contents: read
 'on':
   - push
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/josevnz/SuricataLog/security/code-scanning/1](https://github.com/josevnz/SuricataLog/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs linting and does not require write access, we will set `contents: read` as the minimal required permission. This ensures the workflow has only the necessary access to the repository.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
